### PR TITLE
Enhancing Usability of Mnemonic Wallet Name

### DIFF
--- a/Cosmostation/Base.lproj/Localizable.strings
+++ b/Cosmostation/Base.lproj/Localizable.strings
@@ -78,7 +78,7 @@
 "change_mnemonic_name" = "Change Mnemonic Name";
 "mnemonic_name" = "Mnemonic name";
 "share_text" = "Share Text Address";
-"share_qr" = "Share QrCode Image";
+"share_qr" = "Share QR Code Image";
 "delete_wallet" = "Delete Wallet";
 "delete_wallet_msg" = "All information about this wallet will delete. \nIf you do not backup your mnemonics, you can not find it again!";
 "delete_menmonic" = "Delete Mnemonic";

--- a/Cosmostation/Base/BaseViewController.swift
+++ b/Cosmostation/Base/BaseViewController.swift
@@ -181,11 +181,11 @@ class BaseViewController: UIViewController {
         qrCode?.backgroundColor = CIColor(rgba: "EEEEEE")
         qrCode?.size = CGSize(width: 200, height: 200)
         
-        let attributedString = NSAttributedString(string: nickName ?? "", attributes: [
-            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 18),
+        let attributedString = NSAttributedString(string: address.substring(to: 20) + "..." , attributes: [
+            NSAttributedString.Key.font : UIFont.systemFont(ofSize: 14),
             NSAttributedString.Key.foregroundColor : UIColor.black
         ])
-        let alert = UIAlertController(title: nickName, message: "\n\n\n\n\n\n\n\n", preferredStyle: .alert)
+        let alert = UIAlertController(title: address, message: "\n\n\n\n\n\n\n\n", preferredStyle: .alert)
         alert.setValue(attributedString, forKey: "attributedTitle")
         alert.view.subviews.first?.subviews.first?.subviews.first?.backgroundColor = UIColor.init(hexString: "EEEEEE")
         alert.addAction(UIAlertAction(title: NSLocalizedString("share", comment: ""), style: .default, handler:  { _ in

--- a/Cosmostation/Dao/MWords.swift
+++ b/Cosmostation/Dao/MWords.swift
@@ -45,7 +45,7 @@ public class MWords {
     
     func getName() -> String {
         if (self.nickName == "") {
-            return "Mnemonic " + String(id)
+            return "Account " + String(id)
         }
         return nickName
     }


### PR DESCRIPTION
Big usability concerns using "Mnemonic" as the wallet name, it looks as if I am about to copy the Mnemonic:

<img src="https://user-images.githubusercontent.com/95767439/191413517-c6fb602e-7bc4-4984-80d1-6243353fd3ee.jpeg" alt="Your image title" width="250"/>

- Changing default wallet name from "Mnemonic" to "Account" (same as metamask)
- QR code screen should show what is being copied, not a nick name
- Misspelling of QrCode to QR Code

New Behavior:

![Screen Shot 2022-09-20 at 23 15 16](https://user-images.githubusercontent.com/95767439/191413711-7a8274ec-d593-4445-b1ba-f92e119c8331.png)

Now you know what is being copied.

![Screen Shot 2022-09-20 at 23 15 02](https://user-images.githubusercontent.com/95767439/191413722-2a3a79aa-0dc5-4b43-b7e8-f92646fb67a5.png)


