### PR TITLE
improve NewAccountTypePopup buttons highlight

### DIFF
--- a/Cosmostation.xcodeproj/project.pbxproj
+++ b/Cosmostation.xcodeproj/project.pbxproj
@@ -2635,6 +2635,8 @@
 		28FEDCE926DB141900A43D01 /* KavaIncentiveClaim3ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28FEDCE726DB141900A43D01 /* KavaIncentiveClaim3ViewController.swift */; };
 		28FEDCEA26DB141900A43D01 /* KavaIncentiveClaim3ViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 28FEDCE826DB141900A43D01 /* KavaIncentiveClaim3ViewController.xib */; };
 		51FC6D9984FCBC8504B55E1F /* Pods_Cosmostation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB20D291C0AF536BBDAE928C /* Pods_Cosmostation.framework */; };
+		9F0C15A928DF518100BA24B1 /* TwoLinesButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0C15A828DF518100BA24B1 /* TwoLinesButton.swift */; };
+		9F0C15AA28DF518100BA24B1 /* TwoLinesButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F0C15A828DF518100BA24B1 /* TwoLinesButton.swift */; };
 		C10F8E8103FA540DE8D91196 /* Pods_Cosmostation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BB20D291C0AF536BBDAE928C /* Pods_Cosmostation.framework */; };
 		E10396772875AAB70055903A /* ProposalVotingPeriodCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10396752875AAB70055903A /* ProposalVotingPeriodCell.swift */; };
 		E10396782875AAB70055903A /* ProposalVotingPeriodCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10396752875AAB70055903A /* ProposalVotingPeriodCell.swift */; };
@@ -4078,6 +4080,7 @@
 		28FEDCE726DB141900A43D01 /* KavaIncentiveClaim3ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KavaIncentiveClaim3ViewController.swift; sourceTree = "<group>"; };
 		28FEDCE826DB141900A43D01 /* KavaIncentiveClaim3ViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = KavaIncentiveClaim3ViewController.xib; sourceTree = "<group>"; };
 		8378C93C7F20C3EFF8166D6C /* Pods-CosmostationDev.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-CosmostationDev.debug.xcconfig"; path = "Target Support Files/Pods-CosmostationDev/Pods-CosmostationDev.debug.xcconfig"; sourceTree = "<group>"; };
+		9F0C15A828DF518100BA24B1 /* TwoLinesButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TwoLinesButton.swift; sourceTree = "<group>"; };
 		B928115C5F425560ED5DE8F4 /* Pods-Cosmostation.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Cosmostation.debug.xcconfig"; path = "Target Support Files/Pods-Cosmostation/Pods-Cosmostation.debug.xcconfig"; sourceTree = "<group>"; };
 		BB20D291C0AF536BBDAE928C /* Pods_Cosmostation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Cosmostation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D86957DECC357BB555822802 /* Pods_CosmostationDev.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_CosmostationDev.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -5963,6 +5966,7 @@
 		E1A82DDA224378BE0097CAEE /* View */ = {
 			isa = PBXGroup;
 			children = (
+				9F0C15A828DF518100BA24B1 /* TwoLinesButton.swift */,
 				E19A321D22547DF400A05E41 /* SBCardPopupViewController.swift */,
 				E1A82DDB224378D40097CAEE /* CardView.swift */,
 				E151B638224626990026B8C0 /* BorderButton.swift */,
@@ -7936,6 +7940,7 @@
 				18FFB5D2281AF533004E65BB /* TxInstantContractCell.swift in Sources */,
 				1817CC68283E2CE600523713 /* cosmos_capability_v1beta1_capability.pb.swift in Sources */,
 				18FFB5D3281AF533004E65BB /* SelectAccountCell.swift in Sources */,
+				9F0C15AA28DF518100BA24B1 /* TwoLinesButton.swift in Sources */,
 				18FFB5D7281AF533004E65BB /* CommonHeader.swift in Sources */,
 				0451FC78282A3AC300214FDA /* ChainBinance.swift in Sources */,
 				18FFB5D9281AF533004E65BB /* Cw20BalanceRes.swift in Sources */,
@@ -8147,6 +8152,7 @@
 				151788EC282E078600A7D7CC /* WalletStationCell.swift in Sources */,
 				E1827E112254C92900BC0350 /* WalletDetailViewController.swift in Sources */,
 				040FA89F275F55C200229F6F /* cosmos_slashing_v1beta1_tx.grpc.swift in Sources */,
+				9F0C15A928DF518100BA24B1 /* TwoLinesButton.swift in Sources */,
 				04B1BE2227A3BC4500B1236A /* cosmwasm_wasm_v1_query.grpc.swift in Sources */,
 				047FB700281BD85E009D8AAF /* ManageMnemonicCell.swift in Sources */,
 				04E165B028A0F4A4000F12C0 /* confio_twasm_v1beta1_query.pb.swift in Sources */,

--- a/Cosmostation/Base.lproj/Localizable.strings
+++ b/Cosmostation/Base.lproj/Localizable.strings
@@ -1101,3 +1101,9 @@ support@cosmostation.io";
 "date_format2" = "MMM d, yyyy";
 "date_format3" = "MMM d, yyyy HH:mm";
 "date_format4" = "MMM d, yy HH:mm:ss";
+
+"new_account_restore" = "Restore with";
+"new_account_private_key" = "Private Key";
+"new_account_mnemonic" = "Mnemonic";
+"new_account_watching_only" = "Watching only";
+"new_account_address" = "Address";

--- a/Cosmostation/Controller/PopUp/Base.lproj/NewAccountTypePopup.xib
+++ b/Cosmostation/Controller/PopUp/Base.lproj/NewAccountTypePopup.xib
@@ -4,14 +4,16 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="NewAccountTypePopup" customModule="Cosmostation" customModuleProvider="target">
             <connections>
+                <outlet property="restoreMnemonicButton" destination="cS0-gy-cjQ" id="0U2-ys-syz"/>
+                <outlet property="restorePrivateKeyButton" destination="bua-LS-aeD" id="pZa-Nu-uLy"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
+                <outlet property="watchingOnlyAddressButton" destination="Q2F-1q-ZMN" id="Sjo-nc-VqJ"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -22,172 +24,10 @@
                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="KVd-mF-2dl">
                     <rect key="frame" x="10" y="368" width="394" height="50"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="M3D-X6-Lt6">
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bua-LS-aeD" customClass="TwoLinesButton" customModule="Cosmostation" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="192" height="50"/>
-                            <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h2y-UK-jby">
-                                    <rect key="frame" x="56" y="10" width="80" height="30"/>
-                                    <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Restore with" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hKk-C7-Bk1">
-                                            <rect key="frame" x="5" y="-1" width="70.5" height="14.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                            <color key="textColor" name="photon"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Private Key" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6yW-7B-a8Z">
-                                            <rect key="frame" x="-0.5" y="13.5" width="81" height="19.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="80" id="90j-NU-k4P"/>
-                                        <constraint firstAttribute="bottom" secondItem="6yW-7B-a8Z" secondAttribute="bottom" constant="-3" id="A0h-Tc-CcH"/>
-                                        <constraint firstItem="6yW-7B-a8Z" firstAttribute="centerX" secondItem="h2y-UK-jby" secondAttribute="centerX" id="ei5-dL-SMl"/>
-                                        <constraint firstAttribute="height" constant="30" id="fhn-GE-fRj"/>
-                                        <constraint firstItem="hKk-C7-Bk1" firstAttribute="centerX" secondItem="h2y-UK-jby" secondAttribute="centerX" id="hqR-9e-7US"/>
-                                        <constraint firstItem="hKk-C7-Bk1" firstAttribute="top" secondItem="h2y-UK-jby" secondAttribute="top" constant="-1" id="x41-Fp-uhv"/>
-                                    </constraints>
-                                </view>
-                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bua-LS-aeD">
-                                    <rect key="frame" x="0.0" y="0.0" width="192" height="50"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="50" id="ZJM-1f-jUe"/>
-                                    </constraints>
-                                    <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="15"/>
-                                    <state key="normal">
-                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    </state>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
-                                            <real key="value" value="1"/>
-                                        </userDefinedRuntimeAttribute>
-                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                            <real key="value" value="8"/>
-                                        </userDefinedRuntimeAttribute>
-                                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
-                                            <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        </userDefinedRuntimeAttribute>
-                                    </userDefinedRuntimeAttributes>
-                                    <connections>
-                                        <action selector="onClickPrivateKey:" destination="-1" eventType="touchUpInside" id="5c1-J2-Noq"/>
-                                    </connections>
-                                </button>
-                            </subviews>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
-                                <constraint firstItem="h2y-UK-jby" firstAttribute="centerX" secondItem="bua-LS-aeD" secondAttribute="centerX" id="9f5-0D-oJg"/>
-                                <constraint firstItem="h2y-UK-jby" firstAttribute="centerY" secondItem="bua-LS-aeD" secondAttribute="centerY" id="PDM-ja-quv"/>
-                                <constraint firstAttribute="bottom" secondItem="bua-LS-aeD" secondAttribute="bottom" id="Pev-Tt-MaA"/>
-                                <constraint firstItem="bua-LS-aeD" firstAttribute="leading" secondItem="M3D-X6-Lt6" secondAttribute="leading" id="Qtm-D2-MXu"/>
-                                <constraint firstItem="bua-LS-aeD" firstAttribute="top" secondItem="M3D-X6-Lt6" secondAttribute="top" id="fV9-ic-cHQ"/>
-                                <constraint firstAttribute="trailing" secondItem="bua-LS-aeD" secondAttribute="trailing" id="m8F-Zv-aKp"/>
-                            </constraints>
-                        </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fxo-lD-YLZ">
-                            <rect key="frame" x="202" y="0.0" width="192" height="50"/>
-                            <subviews>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UWq-QA-oI5">
-                                    <rect key="frame" x="56" y="10" width="80" height="30"/>
-                                    <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Mnemonic" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DfQ-F5-a0K">
-                                            <rect key="frame" x="2" y="13.5" width="76" height="19.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                            <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Restore with" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b0k-He-hhw">
-                                            <rect key="frame" x="5" y="-1" width="70.5" height="14.5"/>
-                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                            <color key="textColor" name="photon"/>
-                                            <nil key="highlightedColor"/>
-                                        </label>
-                                    </subviews>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <constraints>
-                                        <constraint firstAttribute="bottom" secondItem="DfQ-F5-a0K" secondAttribute="bottom" constant="-3" id="9oJ-JA-SrV"/>
-                                        <constraint firstItem="b0k-He-hhw" firstAttribute="top" secondItem="UWq-QA-oI5" secondAttribute="top" constant="-1" id="G2h-qI-TUH"/>
-                                        <constraint firstItem="b0k-He-hhw" firstAttribute="centerX" secondItem="UWq-QA-oI5" secondAttribute="centerX" id="cVz-Yv-yH6"/>
-                                        <constraint firstAttribute="height" constant="30" id="hfI-Ok-wZp"/>
-                                        <constraint firstItem="DfQ-F5-a0K" firstAttribute="centerX" secondItem="UWq-QA-oI5" secondAttribute="centerX" id="p89-sy-fvN"/>
-                                        <constraint firstAttribute="width" constant="80" id="yCi-gT-EVH"/>
-                                    </constraints>
-                                </view>
-                                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cS0-gy-cjQ">
-                                    <rect key="frame" x="0.0" y="0.0" width="192" height="50"/>
-                                    <constraints>
-                                        <constraint firstAttribute="height" constant="50" id="sIt-2v-acG"/>
-                                    </constraints>
-                                    <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="15"/>
-                                    <state key="normal">
-                                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    </state>
-                                    <userDefinedRuntimeAttributes>
-                                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
-                                            <real key="value" value="1"/>
-                                        </userDefinedRuntimeAttribute>
-                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                            <real key="value" value="8"/>
-                                        </userDefinedRuntimeAttribute>
-                                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
-                                            <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        </userDefinedRuntimeAttribute>
-                                    </userDefinedRuntimeAttributes>
-                                    <connections>
-                                        <action selector="onClickMnemonic:" destination="-1" eventType="touchUpInside" id="mXC-Nb-ezw"/>
-                                    </connections>
-                                </button>
-                            </subviews>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstItem="UWq-QA-oI5" firstAttribute="centerY" secondItem="cS0-gy-cjQ" secondAttribute="centerY" id="9nX-Nt-t8M"/>
-                                <constraint firstItem="cS0-gy-cjQ" firstAttribute="leading" secondItem="Fxo-lD-YLZ" secondAttribute="leading" id="UE2-N6-xxc"/>
-                                <constraint firstItem="UWq-QA-oI5" firstAttribute="centerX" secondItem="cS0-gy-cjQ" secondAttribute="centerX" id="cQF-5Y-0Wp"/>
-                                <constraint firstItem="cS0-gy-cjQ" firstAttribute="top" secondItem="Fxo-lD-YLZ" secondAttribute="top" id="eae-Cz-hqq"/>
-                                <constraint firstAttribute="bottom" secondItem="cS0-gy-cjQ" secondAttribute="bottom" id="fQP-f1-9ky"/>
-                                <constraint firstAttribute="trailing" secondItem="cS0-gy-cjQ" secondAttribute="trailing" id="zgA-F2-exi"/>
-                            </constraints>
-                        </view>
-                    </subviews>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="50" id="eUa-8U-E5L"/>
-                    </constraints>
-                </stackView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IrH-Ji-Sqh">
-                    <rect key="frame" x="10" y="428" width="394" height="50"/>
-                    <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y1I-eW-cgV">
-                            <rect key="frame" x="157" y="10" width="80" height="30"/>
-                            <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Watching only" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cdq-Wy-eKK">
-                                    <rect key="frame" x="0.0" y="-1" width="80" height="14.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
-                                    <color key="textColor" name="photon"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Address" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="db3-9t-fHm">
-                                    <rect key="frame" x="10.5" y="13.5" width="59.5" height="19.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                            </subviews>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstAttribute="bottom" secondItem="db3-9t-fHm" secondAttribute="bottom" constant="-3" id="Erq-tw-NxE"/>
-                                <constraint firstItem="Cdq-Wy-eKK" firstAttribute="centerX" secondItem="y1I-eW-cgV" secondAttribute="centerX" id="Mta-8p-uO9"/>
-                                <constraint firstAttribute="width" constant="80" id="Sjx-7R-8X3"/>
-                                <constraint firstItem="db3-9t-fHm" firstAttribute="centerX" secondItem="y1I-eW-cgV" secondAttribute="centerX" id="TK6-wm-SYF"/>
-                                <constraint firstAttribute="height" constant="30" id="YkU-Ot-0DR"/>
-                                <constraint firstItem="Cdq-Wy-eKK" firstAttribute="top" secondItem="y1I-eW-cgV" secondAttribute="top" constant="-1" id="eld-eZ-Wjx"/>
-                            </constraints>
-                        </view>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q2F-1q-ZMN">
-                            <rect key="frame" x="0.0" y="0.0" width="394" height="50"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="50" id="HiH-kZ-E4i"/>
+                                <constraint firstAttribute="height" constant="50" id="ZJM-1f-jUe"/>
                             </constraints>
                             <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="15"/>
                             <state key="normal">
@@ -205,49 +45,17 @@
                                 </userDefinedRuntimeAttribute>
                             </userDefinedRuntimeAttributes>
                             <connections>
-                                <action selector="onClickAddress:" destination="-1" eventType="touchUpInside" id="mcy-80-2Xu"/>
+                                <action selector="onClickPrivateKey:" destination="-1" eventType="touchUpInside" id="5c1-J2-Noq"/>
                             </connections>
                         </button>
-                    </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <constraints>
-                        <constraint firstItem="y1I-eW-cgV" firstAttribute="centerX" secondItem="Q2F-1q-ZMN" secondAttribute="centerX" id="3wi-KA-qPi"/>
-                        <constraint firstItem="Q2F-1q-ZMN" firstAttribute="top" secondItem="IrH-Ji-Sqh" secondAttribute="top" id="5Ul-aq-1SW"/>
-                        <constraint firstAttribute="trailing" secondItem="Q2F-1q-ZMN" secondAttribute="trailing" id="WfH-Ie-qU6"/>
-                        <constraint firstAttribute="bottom" secondItem="Q2F-1q-ZMN" secondAttribute="bottom" id="Wvr-0I-hvB"/>
-                        <constraint firstItem="y1I-eW-cgV" firstAttribute="centerY" secondItem="Q2F-1q-ZMN" secondAttribute="centerY" id="egx-tt-xX9"/>
-                        <constraint firstItem="Q2F-1q-ZMN" firstAttribute="leading" secondItem="IrH-Ji-Sqh" secondAttribute="leading" id="mfZ-19-Bau"/>
-                    </constraints>
-                </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ixe-DH-FdE">
-                    <rect key="frame" x="10" y="488" width="394" height="50"/>
-                    <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TFP-tg-NnF">
-                            <rect key="frame" x="157" y="10" width="80" height="30"/>
-                            <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aVK-Nh-nYN">
-                                    <rect key="frame" x="14.5" y="5" width="51" height="20.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                            </subviews>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cS0-gy-cjQ" customClass="TwoLinesButton" customModule="Cosmostation" customModuleProvider="target">
+                            <rect key="frame" x="202" y="0.0" width="192" height="50"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="80" id="WXy-YB-nGk"/>
-                                <constraint firstAttribute="height" constant="30" id="gBP-S4-Ghi"/>
-                                <constraint firstItem="aVK-Nh-nYN" firstAttribute="centerY" secondItem="TFP-tg-NnF" secondAttribute="centerY" id="jw8-QC-C4i"/>
-                                <constraint firstItem="aVK-Nh-nYN" firstAttribute="centerX" secondItem="TFP-tg-NnF" secondAttribute="centerX" id="vf5-ax-KsO"/>
-                            </constraints>
-                        </view>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oiN-eL-Fen">
-                            <rect key="frame" x="0.0" y="0.0" width="394" height="50"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="50" id="6EU-jG-PJE"/>
+                                <constraint firstAttribute="height" constant="50" id="sIt-2v-acG"/>
                             </constraints>
                             <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="15"/>
                             <state key="normal">
-                                <color key="titleColor" name="_font05"/>
+                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </state>
                             <userDefinedRuntimeAttributes>
                                 <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
@@ -261,45 +69,89 @@
                                 </userDefinedRuntimeAttribute>
                             </userDefinedRuntimeAttributes>
                             <connections>
-                                <action selector="onClickCreate:" destination="-1" eventType="touchUpInside" id="jMe-IB-xhZ"/>
+                                <action selector="onClickMnemonic:" destination="-1" eventType="touchUpInside" id="mXC-Nb-ezw"/>
                             </connections>
                         </button>
                     </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstItem="oiN-eL-Fen" firstAttribute="leading" secondItem="ixe-DH-FdE" secondAttribute="leading" id="8VP-Es-H3E"/>
-                        <constraint firstAttribute="trailing" secondItem="oiN-eL-Fen" secondAttribute="trailing" id="JhN-pJ-kTA"/>
-                        <constraint firstItem="oiN-eL-Fen" firstAttribute="top" secondItem="ixe-DH-FdE" secondAttribute="top" id="UIo-fV-1UR"/>
-                        <constraint firstAttribute="bottom" secondItem="oiN-eL-Fen" secondAttribute="bottom" id="Uht-OR-moe"/>
-                        <constraint firstItem="TFP-tg-NnF" firstAttribute="centerY" secondItem="oiN-eL-Fen" secondAttribute="centerY" id="bt8-uR-d5n"/>
-                        <constraint firstItem="TFP-tg-NnF" firstAttribute="centerX" secondItem="oiN-eL-Fen" secondAttribute="centerX" id="peR-u1-Lem"/>
+                        <constraint firstAttribute="height" constant="50" id="eUa-8U-E5L"/>
                     </constraints>
-                </view>
+                </stackView>
+                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q2F-1q-ZMN" customClass="TwoLinesButton" customModule="Cosmostation" customModuleProvider="target">
+                    <rect key="frame" x="10" y="428" width="394" height="50"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="50" id="HiH-kZ-E4i"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="15"/>
+                    <state key="normal">
+                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </state>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                            <real key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="8"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                            <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="onClickAddress:" destination="-1" eventType="touchUpInside" id="mcy-80-2Xu"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" horizontalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oiN-eL-Fen">
+                    <rect key="frame" x="10" y="488" width="394" height="50"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="50" id="6EU-jG-PJE"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <state key="normal" title="Create">
+                        <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </state>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                            <real key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="8"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                            <color key="value" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                    <connections>
+                        <action selector="onClickCreate:" destination="-1" eventType="touchUpInside" id="jMe-IB-xhZ"/>
+                    </connections>
+                </button>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="IrH-Ji-Sqh" secondAttribute="trailing" constant="10" id="4n1-YS-E0g"/>
-                <constraint firstItem="ixe-DH-FdE" firstAttribute="top" secondItem="IrH-Ji-Sqh" secondAttribute="bottom" constant="10" id="ALj-Xw-liw"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="ixe-DH-FdE" secondAttribute="bottom" constant="324" id="NMj-47-tFQ"/>
-                <constraint firstItem="KVd-mF-2dl" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="324" id="S3m-Kf-WLi"/>
-                <constraint firstItem="ixe-DH-FdE" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="UfK-no-JuA"/>
+                <constraint firstItem="Q2F-1q-ZMN" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" id="4Gw-F1-0bd"/>
+                <constraint firstItem="oiN-eL-Fen" firstAttribute="top" secondItem="Q2F-1q-ZMN" secondAttribute="bottom" constant="10" id="6Qp-Fr-RIE"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="oiN-eL-Fen" secondAttribute="trailing" constant="10" id="7sl-cz-qO3"/>
+                <constraint firstItem="KVd-mF-2dl" firstAttribute="top" relation="greaterThanOrEqual" secondItem="fnl-2z-Ty3" secondAttribute="top" id="S3m-Kf-WLi"/>
                 <constraint firstItem="KVd-mF-2dl" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="Uir-jc-IW7"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="ixe-DH-FdE" secondAttribute="trailing" constant="10" id="iW9-iT-KOo"/>
+                <constraint firstItem="Q2F-1q-ZMN" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="VPN-hc-KnW"/>
+                <constraint firstItem="oiN-eL-Fen" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="Y9a-cr-wNe"/>
+                <constraint firstItem="Q2F-1q-ZMN" firstAttribute="top" secondItem="KVd-mF-2dl" secondAttribute="bottom" constant="10" id="l0y-mF-XOo"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="KVd-mF-2dl" secondAttribute="trailing" constant="10" id="mth-Hv-gLh"/>
-                <constraint firstItem="IrH-Ji-Sqh" firstAttribute="centerY" secondItem="fnl-2z-Ty3" secondAttribute="centerY" id="udf-Oz-w3E"/>
-                <constraint firstItem="IrH-Ji-Sqh" firstAttribute="top" secondItem="KVd-mF-2dl" secondAttribute="bottom" constant="10" id="x7X-xE-lKW"/>
-                <constraint firstItem="IrH-Ji-Sqh" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="10" id="zTL-e6-6rg"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Q2F-1q-ZMN" secondAttribute="trailing" constant="10" id="wk7-yG-Fc0"/>
             </constraints>
             <point key="canvasLocation" x="137.68115942028987" y="97.767857142857139"/>
         </view>
     </objects>
-    <resources>
-        <namedColor name="_font05">
-            <color red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="photon">
-            <color red="0.0" green="0.71799999475479126" blue="0.75300002098083496" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-    </resources>
+    <designables>
+        <designable name="Q2F-1q-ZMN">
+            <size key="intrinsicContentSize" width="30" height="30"/>
+        </designable>
+        <designable name="bua-LS-aeD">
+            <size key="intrinsicContentSize" width="30" height="30"/>
+        </designable>
+        <designable name="cS0-gy-cjQ">
+            <size key="intrinsicContentSize" width="30" height="30"/>
+        </designable>
+    </designables>
 </document>

--- a/Cosmostation/Controller/PopUp/NewAccountTypePopup.swift
+++ b/Cosmostation/Controller/PopUp/NewAccountTypePopup.swift
@@ -12,11 +12,23 @@ class NewAccountTypePopup: BaseViewController, SBCardPopupContent {
     var popupViewController: SBCardPopupViewController?
     let allowsTapToDismissPopupCard = true
     let allowsSwipeToDismissPopupCard = true
-
+    @IBOutlet weak var restorePrivateKeyButton: TwoLinesButton!
+    @IBOutlet weak var restoreMnemonicButton: TwoLinesButton!
+    @IBOutlet weak var watchingOnlyAddressButton: TwoLinesButton!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         let tap = UITapGestureRecognizer(target: self, action: #selector(onTapClose))
         self.view.addGestureRecognizer(tap)
+        restorePrivateKeyButton.setTitle(firstLineTitle: NSLocalizedString("new_account_restore", comment: ""), firstLineColor: .init(named: "photon"),
+                                         secondLineText: NSLocalizedString("new_account_private_key", comment: ""), secondLineColor: .white,
+                                         state: .normal)
+        restoreMnemonicButton.setTitle(firstLineTitle: NSLocalizedString("new_account_restore", comment: ""), firstLineColor: .init(named: "photon"),
+                                         secondLineText: NSLocalizedString("new_account_mnemonic", comment: ""), secondLineColor: .white,
+                                         state: .normal)
+        watchingOnlyAddressButton.setTitle(firstLineTitle: NSLocalizedString("new_account_watching_only", comment: ""), firstLineColor: .init(named: "photon"),
+                                         secondLineText: NSLocalizedString("new_account_address", comment: ""), secondLineColor: .white,
+                                         state: .normal)
     }
     
     @objc func onTapClose(sender: Any) {

--- a/Cosmostation/Controller/PopUp/ko.lproj/NewAccountTypePopup.strings
+++ b/Cosmostation/Controller/PopUp/ko.lproj/NewAccountTypePopup.strings
@@ -1,21 +1,3 @@
 
-/* Class = "UILabel"; text = "Private Key"; ObjectID = "6yW-7B-a8Z"; */
-"6yW-7B-a8Z.text" = "개인키";
-
-/* Class = "UILabel"; text = "Watching only"; ObjectID = "Cdq-Wy-eKK"; */
-"Cdq-Wy-eKK.text" = "관찰 모드";
-
-/* Class = "UILabel"; text = "Mnemonic"; ObjectID = "DfQ-F5-a0K"; */
-"DfQ-F5-a0K.text" = "복구문자";
-
-/* Class = "UILabel"; text = "Create"; ObjectID = "aVK-Nh-nYN"; */
-"aVK-Nh-nYN.text" = "지갑 생성";
-
-/* Class = "UILabel"; text = "Restore with"; ObjectID = "b0k-He-hhw"; */
-"b0k-He-hhw.text" = "지갑 복원";
-
-/* Class = "UILabel"; text = "Address"; ObjectID = "db3-9t-fHm"; */
-"db3-9t-fHm.text" = "주소";
-
-/* Class = "UILabel"; text = "Restore with"; ObjectID = "hKk-C7-Bk1"; */
-"hKk-C7-Bk1.text" = "지갑 복원";
+/* Class = "UIButton"; normalTitle = "Create"; ObjectID = "oiN-eL-Fen"; */
+"oiN-eL-Fen.normalTitle" = "지갑 생성";

--- a/Cosmostation/View/TwoLinesButton.swift
+++ b/Cosmostation/View/TwoLinesButton.swift
@@ -1,0 +1,52 @@
+//
+//  TwoLineButton.swift
+//  Cosmostation
+//
+//  Created by albertopeam on 24/9/22.
+//  Copyright © 2022 wannabit. All rights reserved.
+//
+
+import UIKit
+
+/// Two lines button
+final class TwoLinesButton: UIButton {
+    
+    convenience init() {
+        self.init(type: .system)
+    }
+    
+    /**
+     Sets the title in two row format using the respective colors
+     
+     - Parameter firstLineTitle: title for the first line
+     - Parameter firstLineColor: color for the first line
+     - Parameter secondLineText: title for the second line
+     - Parameter secondLineColor: color for the second line
+     - Parameter state: state where the title applies
+     */
+    func setTitle(firstLineTitle: String, firstLineColor: UIColor?,
+                  secondLineText: String, secondLineColor: UIColor?,
+                  state: UIControl.State) {
+        titleLabel?.numberOfLines = 2
+        
+        let attributedString = NSMutableAttributedString()
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+        
+        let labelAttribute = [
+            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 12),
+            NSAttributedString.Key.foregroundColor: firstLineColor ?? .white,
+            NSAttributedString.Key.paragraphStyle: paragraph
+        ]
+        attributedString.append(NSAttributedString(string: firstLineTitle, attributes: labelAttribute))
+        
+        let textAttribute = [
+            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 16),
+            NSAttributedString.Key.foregroundColor: secondLineColor ?? .white,
+            NSAttributedString.Key.paragraphStyle: paragraph
+        ]
+        attributedString.append(NSAttributedString(string: "\n \(secondLineText)", attributes: textAttribute))
+        
+        setAttributedTitle(attributedString, for: state)
+    }
+}

--- a/Cosmostation/ko.lproj/Localizable.strings
+++ b/Cosmostation/ko.lproj/Localizable.strings
@@ -1107,3 +1107,9 @@ support@cosmostation.io";
 "date_format2" = "yyyy-MM-dd";
 "date_format3" = "yyyy-MM-dd HH:mm";
 "date_format4" = "yy-MM-dd HH:mm:ss";
+
+"new_account_restore" = "지갑 복원";
+"new_account_private_key" = "개인키";
+"new_account_mnemonic" = "복구문자";
+"new_account_watching_only" = "관찰 모드";
+"new_account_address" = "주소";


### PR DESCRIPTION
Create TwoLinesButton component that represent a button with two lines of attributed text.
Use the component to improve NewAccountTypePopup.xib, so design is maintained and tap highlight is available.
Simplify NewAccountTypePopup.xib: removed not needed Labels and nested Views

Verified UI on:
* iPhone SE(1st gen) 12.4 and 13.0.
* iPhone SE(2nd gen) 14.0
* iPhone 13 mini 15.5

How it looks on iOS12.4
Before:
![NOFIXED - iPhone SE (1st generation) 12 4](https://user-images.githubusercontent.com/912381/192162869-b6728142-8831-4c77-a22b-08f4a58393d6.png)
After:
![fixed - iPhone SE (1st generation) 12 4](https://user-images.githubusercontent.com/912381/192162882-d343ebe7-6944-4390-a2b2-628abfa47274.png)

