### PR TITLE
UI improvements on PrivateKeyRestoreViewController 

### DIFF
--- a/Cosmostation/Base.lproj/Localizable.strings
+++ b/Cosmostation/Base.lproj/Localizable.strings
@@ -1107,3 +1107,5 @@ support@cosmostation.io";
 "new_account_mnemonic" = "Mnemonic";
 "new_account_watching_only" = "Watching only";
 "new_account_address" = "Address";
+
+"private_key_restore_priv_key" = "Private Key";

--- a/Cosmostation/Controller/Setting/PrivateKeyRestoreViewController.swift
+++ b/Cosmostation/Controller/Setting/PrivateKeyRestoreViewController.swift
@@ -15,13 +15,15 @@ class PrivateKeyRestoreViewController: BaseViewController, QrScannerDelegate, Pa
     @IBOutlet weak var btnCancel: UIButton!
     @IBOutlet weak var btnScan: UIButton!
     @IBOutlet weak var btnPaste: UIButton!
-    var userInput: String?
+    @IBOutlet weak var btnNext: UIButton!
+    private var userInput: String = ""
     
     override func viewDidLoad() {
         super.viewDidLoad()
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(self.dismissKeyboard (_:)))
         self.view.addGestureRecognizer(tapGesture)
-        keyInputText.placeholder = "Private Key"
+        keyInputText.placeholder = NSLocalizedString("private_key_restore_priv_key", comment: "")
+        keyInputText.delegate = self
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -34,7 +36,6 @@ class PrivateKeyRestoreViewController: BaseViewController, QrScannerDelegate, Pa
     @objc func dismissKeyboard (_ sender: UITapGestureRecognizer) {
         self.view.endEditing(true)
     }
-    
     
     @IBAction func onClickScan(_ sender: UIButton) {
         let qrScanVC = QRScanViewController(nibName: "QRScanViewController", bundle: nil)
@@ -61,7 +62,7 @@ class PrivateKeyRestoreViewController: BaseViewController, QrScannerDelegate, Pa
     
     @IBAction func onClickNext(_ sender: UIButton) {
         userInput = keyInputText.text?.trimmingCharacters(in: .whitespaces) ?? ""
-        if (!KeyFac.isValidStringPrivateKey(userInput!)) {
+        if (!KeyFac.isValidStringPrivateKey(userInput)) {
             self.onShowToast(NSLocalizedString("error_invalid_private_Key", comment: ""))
             return
         }
@@ -105,7 +106,7 @@ class PrivateKeyRestoreViewController: BaseViewController, QrScannerDelegate, Pa
     
     func onStartWalletDerive() {
         let walletDeriveVC = WalletDeriveViewController(nibName: "WalletDeriveViewController", bundle: nil)
-        walletDeriveVC.mPrivateKey = KeyFac.getPrivateFromString(self.userInput!)
+        walletDeriveVC.mPrivateKey = KeyFac.getPrivateFromString(userInput)
         walletDeriveVC.mPrivateKeyMode = true
         walletDeriveVC.mBackable = false
         self.navigationItem.title = ""
@@ -118,4 +119,15 @@ class PrivateKeyRestoreViewController: BaseViewController, QrScannerDelegate, Pa
         btnPaste.borderColor = UIColor.init(named: "_font05")
     }
 
+}
+
+// MARK: - UITextFieldDelegate
+
+extension PrivateKeyRestoreViewController: UITextFieldDelegate {
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        defer {
+            onClickNext(btnNext)
+        }
+        return textField.resignFirstResponder()
+    }
 }

--- a/Cosmostation/Controller/Setting/PrivateKeyRestoreViewController.xib
+++ b/Cosmostation/Controller/Setting/PrivateKeyRestoreViewController.xib
@@ -13,6 +13,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="PrivateKeyRestoreViewController" customModule="Cosmostation" customModuleProvider="target">
             <connections>
                 <outlet property="btnCancel" destination="cBr-nV-enY" id="JMV-5R-wPd"/>
+                <outlet property="btnNext" destination="fQY-o7-Zap" id="YA6-rB-hhD"/>
                 <outlet property="btnPaste" destination="N4q-Q5-akk" id="Zy0-lf-Qzx"/>
                 <outlet property="btnScan" destination="DUU-tf-af4" id="iMT-Pe-eBu"/>
                 <outlet property="keyInputText" destination="PfV-KH-1UD" id="6h6-P1-Odx"/>
@@ -43,13 +44,14 @@ The private key is a 66-digit string starting with 0x.</string>
                     <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="12"/>
                     <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="alphabet" returnKeyType="done" smartInsertDeleteType="no"/>
                 </textField>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DUU-tf-af4">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DUU-tf-af4">
                     <rect key="frame" x="170" y="159.5" width="110" height="30"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="110" id="bBS-Nc-au1"/>
                         <constraint firstAttribute="height" constant="30" id="rY9-hP-oko"/>
                     </constraints>
                     <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="14"/>
+                    <color key="tintColor" name="_font05"/>
                     <state key="normal" title=" QR Scan" image="btnIconScan">
                         <color key="titleColor" name="_font05"/>
                     </state>
@@ -68,13 +70,14 @@ The private key is a 66-digit string starting with 0x.</string>
                         <action selector="onClickScan:" destination="-1" eventType="touchUpInside" id="x95-QW-ZzG"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N4q-Q5-akk">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N4q-Q5-akk">
                     <rect key="frame" x="288" y="159.5" width="110" height="30"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="30" id="wVl-Vy-gjr"/>
                         <constraint firstAttribute="width" constant="110" id="xar-4c-2uE"/>
                     </constraints>
                     <fontDescription key="fontDescription" name="Helvetica" family="Helvetica" pointSize="14"/>
+                    <color key="tintColor" name="_font05"/>
                     <state key="normal" title="Paste" image="btnIconPaste">
                         <color key="titleColor" name="_font05"/>
                     </state>

--- a/Cosmostation/ko.lproj/Localizable.strings
+++ b/Cosmostation/ko.lproj/Localizable.strings
@@ -1113,3 +1113,5 @@ support@cosmostation.io";
 "new_account_mnemonic" = "복구문자";
 "new_account_watching_only" = "관찰 모드";
 "new_account_address" = "주소";
+
+"private_key_restore_priv_key" = "개인키";


### PR DESCRIPTION
fixed qrScan and paste buttons tap highlight. 
added hide keyboard when tapping done on it. 
moved hardcoded string to localizables

UI tested on:
iPhoneSE(2nd gen) 13.5
iPhoneSE(2nd gen) 14.0
iPhoneSE(3rd gen) 15.5