### PR TITLE
Bugfix: handle properly row indexes to avoid crashing while reloading

### DIFF
--- a/Cosmostation/Controller/Setting/WalletDetailViewController.swift
+++ b/Cosmostation/Controller/Setting/WalletDetailViewController.swift
@@ -127,7 +127,7 @@ class WalletDetailViewController: BaseViewController, UITableViewDelegate, UITab
                 self.selectedAccount.account_nick_name = trimmedString!
                 BaseData.instance.updateAccount(self.selectedAccount)
                 BaseData.instance.setNeedRefresh(true)
-                self.onReloadTableView(1)
+                self.onReloadTableView(0)
             }
         }))
         self.present(nameAlert, animated: true) {
@@ -304,7 +304,7 @@ class WalletDetailViewController: BaseViewController, UITableViewDelegate, UITab
                 }
                 try channel.close().wait()
             } catch { print("onFetchRewardAddress_gRPC failed: \(error)") }
-            self.onReloadTableView(3)
+            self.onReloadTableView(2)
         }
     }
     
@@ -317,7 +317,7 @@ class WalletDetailViewController: BaseViewController, UITableViewDelegate, UITab
                     return
                 }
                 self.chainId = NodeInfo.init(nodeInfo).network ?? ""
-                self.onReloadTableView(2)
+                self.onReloadTableView(1)
                 
             case .failure(let error):
                 print("onFetchNodeInfo ", error)
@@ -335,7 +335,7 @@ class WalletDetailViewController: BaseViewController, UITableViewDelegate, UITab
                 }
                 try channel.close().wait()
             } catch { print("onFetchgRPCNodeInfo failed: \(error)") }
-            self.onReloadTableView(2)
+            self.onReloadTableView(1)
         }
     }
 }


### PR DESCRIPTION
fixed crash in WalletDetailViewController while reloadRows in a position that is out of bounds. 

Steps to reproduce the issue:
1. access the app in wallet watch mode(probably it can be done in other mode, not verified)
2. go to "Settings" tab
3. tap "Manage wallet"
4. tap to access one of the networks "wallet detail"
5. the app is crashing as index 3 is reloaded. Reason: the table contains 3 cells with indexes: 0, 1 and 2. Fix: update the `onReloadTableView` calls with appropriate indexes


https://user-images.githubusercontent.com/912381/193927243-3438f7d7-aa87-494d-b778-abc51e5196fc.mov

