### PR TITLE
simplified usage of Cosmos_Bank_V1beta1_QueryClient

### DIFF
--- a/Cosmostation/Cell/GranterViewCell.swift
+++ b/Cosmostation/Cell/GranterViewCell.swift
@@ -22,24 +22,18 @@ class GranterViewCell: UITableViewCell {
     }
     
     func onBindView(_ chainConfig: ChainConfig?, _ address: String) {
-        if (chainConfig == nil) { return }
+        guard let chainConfig = chainConfig else { return }
         granterAddressLabel.text = address
         
-        var tempCoin = Coin.init(chainConfig!.stakeDenom, "0")
+        var tempCoin = Coin.init(chainConfig.stakeDenom, "0")
         DispatchQueue.global().async {
             do {
-                let channel = BaseNetWork.getConnection(chainConfig!.chainType, MultiThreadedEventLoopGroup(numberOfThreads: 1))!
-                let page = Cosmos_Base_Query_V1beta1_PageRequest.with { $0.limit = 2000 }
-                let req = Cosmos_Bank_V1beta1_QueryAllBalancesRequest.with { $0.address = address; $0.pagination = page }
-                if let response = try? Cosmos_Bank_V1beta1_QueryClient(channel: channel).allBalances(req, callOptions: BaseNetWork.getCallOptions()).response.wait() {
-                    response.balances.forEach { balance in
-                        if (balance.denom == chainConfig!.stakeDenom) {
-                            tempCoin = Coin.init(balance.denom, balance.amount)
-                        }
-                    }
+                let channel = BaseNetWork.getConnection(chainConfig.chainType, MultiThreadedEventLoopGroup(numberOfThreads: 1))!
+                let req = Cosmos_Bank_V1beta1_QueryBalanceRequest.with { $0.address = address; $0.denom = chainConfig.stakeDenom }
+                if let response = try? Cosmos_Bank_V1beta1_QueryClient(channel: channel).balance(req, callOptions: BaseNetWork.getCallOptions()).response.wait() {
+                    tempCoin = Coin.init(response.balance.denom, response.balance.amount)
                 }
                 try channel.close().wait()
-                
             } catch { }
             DispatchQueue.main.async(execute: {
                 WDP.dpCoin(chainConfig, tempCoin, self.granterAvailableDenomLabel, self.granterAvailableAmountLabel)

--- a/Cosmostation/Controller/Setting/WalletDeriveViewController.swift
+++ b/Cosmostation/Controller/Setting/WalletDeriveViewController.swift
@@ -217,17 +217,11 @@ class WalletDeriveViewController: BaseViewController, UITableViewDelegate, UITab
             DispatchQueue.global().async {
                 do {
                     let channel = BaseNetWork.getConnection(chainConfig.chainType, MultiThreadedEventLoopGroup(numberOfThreads: 1))!
-                    let page = Cosmos_Base_Query_V1beta1_PageRequest.with { $0.limit = 2000 }
-                    let req = Cosmos_Bank_V1beta1_QueryAllBalancesRequest.with { $0.address = derive.dpAddress; $0.pagination = page }
-                    if let response = try? Cosmos_Bank_V1beta1_QueryClient(channel: channel).allBalances(req, callOptions: BaseNetWork.getCallOptions()).response.wait() {
-                        response.balances.forEach { balance in
-                            if (balance.denom == chainConfig.stakeDenom) {
-                                tempCoin = Coin.init(balance.denom, balance.amount)
-                            }
-                        }
+                    let req = Cosmos_Bank_V1beta1_QueryBalanceRequest.with { $0.address = derive.dpAddress; $0.denom = chainConfig.stakeDenom }
+                    if let response = try? Cosmos_Bank_V1beta1_QueryClient(channel: channel).balance(req, callOptions: BaseNetWork.getCallOptions()).response.wait() {
+                        tempCoin = Coin.init(response.balance.denom, response.balance.amount)                        
                     }
                     try channel.close().wait()
-                    
                 } catch { }
                 DispatchQueue.main.async(execute: {
                     self.mDerives[position].coin = tempCoin


### PR DESCRIPTION
replaced `Cosmos_Bank_V1beta1_QueryClient.allBalances()` with `Cosmos_Bank_V1beta1_QueryClient.balance()` as we are only using one, not the entire list