### PR TITLE
fix starname validation logic

### DIFF
--- a/Cosmostation/Controller/Main/starname/StarNameListViewController.swift
+++ b/Cosmostation/Controller/Main/starname/StarNameListViewController.swift
@@ -49,9 +49,11 @@ class StarNameListViewController: BaseViewController {
 
 extension WUtils {
     static func isStarnameValidStarName(_ starname: String) -> Bool {
-        if (starname.starts(with: "*") && starname.count > 3) { return true }
-        let names = starname.split(separator: "*")
+        let names = starname.split(separator: "*", omittingEmptySubsequences: false)
         if (names.count != 2)  { return false }
+        if(String(names[0]).isEmpty) { 
+            return isStarnameValidDomain(String(names[1])) 
+        }
         return (isStarnameValidAccount(String(names[0])) && isStarnameValidDomain(String(names[1])))
     }
     


### PR DESCRIPTION
Current validation logic is incorrect and will produce **Unregistered NameService** error for starnames with `length < 3`
https://github.com/cosmostation/cosmostation-ios/issues/294#issue-1649198344
