### PR TITLE
Fix spelling error in Swift Files

### DIFF
--- a/Cosmostation/Base/BaseAccount.swift
+++ b/Cosmostation/Base/BaseAccount.swift
@@ -315,7 +315,7 @@ public enum PubKeyType: Int {
     case BTC_Taproot = 9
     case unknown = 99
     
-    var algorhythm: String? {
+    var algorithm: String? {
         switch self {
         case PubKeyType.ETH_Keccak256:
             return "keccak256"

--- a/Cosmostation/Base/BaseAccount.swift
+++ b/Cosmostation/Base/BaseAccount.swift
@@ -315,7 +315,7 @@ public enum PubKeyType: Int {
     case BTC_Taproot = 9
     case unknown = 99
     
-    var algorithm: String? {
+    var algorhythm: String? {
         switch self {
         case PubKeyType.ETH_Keccak256:
             return "keccak256"

--- a/Cosmostation/Base/BaseData.swift
+++ b/Cosmostation/Base/BaseData.swift
@@ -773,7 +773,7 @@ extension BaseData {
         return last < now
     }
     
-    // set user last seleted swap ui for convenience
+    // set user last selected swap ui for convenience
     // [fromChainTag, fromChainDenom, toChainTag, toChainDenom]
     func setLastSwapSet(_ swapSet: [String]) {
         if let encoded = try? JSONEncoder().encode(swapSet) {

--- a/Cosmostation/Chains/BaseChain.swift
+++ b/Cosmostation/Chains/BaseChain.swift
@@ -11,7 +11,7 @@ import SwiftyJSON
 import BigInt
 
 class BaseChain {
-    //account and commmon info
+    //account and common info
     var name: String!
     var tag: String!
     var logo1: String!

--- a/Cosmostation/Controller/Main/CosmosClass/CosmosClassVC.swift
+++ b/Cosmostation/Controller/Main/CosmosClass/CosmosClassVC.swift
@@ -287,7 +287,7 @@ class CosmosClassVC: BaseVC {
                     self.onClaimCommissionTx()
                 }
             }
-//            if !(selectedChain is ChainBeraEVM) {                                                                       //disbale for bera
+//            if !(selectedChain is ChainBeraEVM) {                                                                       //disable for bera
                 mainFab.addItem(title: "Compound All", image: UIImage(named: "iconFabCompounding")) { _ in
                     self.onClaimCompoundingTx()
                 }

--- a/Cosmostation/Resource/ProtoBuff/Artela/artela_evm_v1_genesis.pb.swift
+++ b/Cosmostation/Resource/ProtoBuff/Artela/artela_evm_v1_genesis.pb.swift
@@ -54,7 +54,7 @@ struct Artela_Evm_V1_GenesisAccount {
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
-  /// address defines an ethereum hex formated address of an account
+  /// address defines an ethereum hex formatted address of an account
   var address: String = String()
 
   /// code defines the hex bytes of the account code.


### PR DESCRIPTION
- Corrected "seleted" → "selected" in the comment for the `setLastSwapSet` function.
  
- Corrected "commmon" → "common" in the comment about account and common info.

- Fixed the typo "disbale" → "disable" in the commented-out line for disabling the `ChainBeraEVM` functionality.

- Corrected "formated" → "formatted" in the comment about the Ethereum address.
