### PR TITLE
Fix typos and naming consistency in Cosmostation utils

### DIFF
--- a/Cosmostation/Utils/Crypto/SegwitAddrCoder.swift
+++ b/Cosmostation/Utils/Crypto/SegwitAddrCoder.swift
@@ -85,7 +85,7 @@ extension SegwitAddrCoder {
             case .hrpMismatch(let got, let expected):
                 return "Human-readable-part \"\(got)\" does not match requested \"\(expected)\""
             case .segwitV0ProgramSizeMismatch(let size):
-                return "Segwit program size \(size) does not meet version 0 requirments"
+                return "Segwit program size \(size) does not meet version 0 requirements"
             case .segwitVersionNotSupported(let version):
                 return "Segwit version \(version) is not supported by this decoder"
             }

--- a/Cosmostation/Utils/WUtils.swift
+++ b/Cosmostation/Utils/WUtils.swift
@@ -272,13 +272,13 @@ public class WUtils {
         if (address?.isEmpty == true) {
             return false
         }
-        if let evmAddess = EthereumAddress.init(address!) {
+        if let evmAddress = EthereumAddress.init(address!) {
             return true
         }
         return false
     }
     
-    static func isValidSuiAdderss(_ address: String?) -> Bool {
+    static func isValidSuiAddress(_ address: String?) -> Bool {
         let suiPattern = "^(0x)[A-Fa-f0-9]{64}$"
         return address?.range(of: suiPattern, options: .regularExpression ) != nil
     }


### PR DESCRIPTION
SegwitAddrCoder.swift

Fixed typo: requirments → requirements in Segwit error message.

WUtils.swift

Corrected variable name: evmAddess → evmAddress.

Fixed function name typo: isValidSuiAdderss → isValidSuiAddress.